### PR TITLE
Fix undefined name query_by_code()

### DIFF
--- a/test/dao/trade/position_test.py
+++ b/test/dao/trade/position_test.py
@@ -17,4 +17,4 @@ class PositionTest(unittest.TestCase):
 
     def test_query(self):
         position_dao = Position_Dao()
-        query_by_code('601800')
+        position_dao.query_by_code('601800')


### PR DESCRIPTION
$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./quant/test/dao/trade/position_test.py:20:9: F821 undefined name 'query_by_code'
        query_by_code('601800')        ^
1     F821 undefined name 'query_by_code'
1
```